### PR TITLE
Fix GitHub Action Cache Problem

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -74,7 +74,7 @@ jobs:
     # Sets up python and loads packages from the cache.
     - name: Try Cache
       id: python
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ./modules
@@ -83,7 +83,7 @@ jobs:
  
     - name: Cache SDK Toolchain
       id: cache-sdk
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /home/runner/zephyr-sdk-0.12.4
         key: zephyr-sdk-0.12.4


### PR DESCRIPTION
Summary:
- action/cache not support v2 now
- update action/cache to v4